### PR TITLE
test(users): enhance unit tests for municipality user operations with…

### DIFF
--- a/apps/api/src/modules/users/users.controller.spec.ts
+++ b/apps/api/src/modules/users/users.controller.spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import { CreateMunicipalityUserDto, User } from '@repo/api';
+import { CreateMunicipalityUserDto, UpdateMunicipalityUserDto, User } from '@repo/api';
+import { NotFoundException, ConflictException } from '@nestjs/common';
 
 // Mock "nanoid" per evitare problemi ESM
 jest.mock('nanoid', () => ({ nanoid: () => 'mocked-id' }));
 
-// Mock finto per i guard
 const mockSessionGuard = { canActivate: jest.fn(() => true) };
 const mockRolesGuard = { canActivate: jest.fn(() => true) };
 
@@ -17,14 +17,16 @@ describe('UsersController', () => {
   beforeEach(async () => {
     const mockUsersService: Partial<jest.Mocked<UsersService>> = {
       findMunicipalityUsers: jest.fn(),
+      findMunicipalityUserById: jest.fn(),
       createMunicipalityUser: jest.fn(),
+      deleteMunicipalityUserById: jest.fn(),
+      updateMunicipalityUserById: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
       providers: [{ provide: UsersService, useValue: mockUsersService }],
     })
-      // sovrascrive i guard globali usati nel controller
       .overrideGuard(require('../auth/guards/session-auth.guard').SessionGuard)
       .useValue(mockSessionGuard)
       .overrideGuard(require('../auth/guards/roles.guard').RolesGuard)
@@ -48,6 +50,31 @@ describe('UsersController', () => {
 
       expect(usersService.findMunicipalityUsers).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ success: true, data: mockUsers });
+    });
+  });
+
+  describe('getMunicipalityUserById', () => {
+    it('should return a municipality user by id', async () => {
+      const mockUser: Partial<User> = {
+        id: '1',
+        email: 'admin@city.gov',
+        role: { id: 'role-id', name: 'admin' } as any,
+      };
+
+      usersService.findMunicipalityUserById.mockResolvedValue(mockUser as User);
+
+      const result = await controller.getMunicipalityUserById('1');
+
+      expect(usersService.findMunicipalityUserById).toHaveBeenCalledWith('1');
+      expect(result).toEqual({ success: true, data: mockUser });
+    });
+
+    it('should throw if UsersService.findMunicipalityUserById throws', async () => {
+      usersService.findMunicipalityUserById.mockRejectedValue(
+        new NotFoundException('Municipality user not found'),
+      );
+
+      await expect(controller.getMunicipalityUserById('999')).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -87,12 +114,69 @@ describe('UsersController', () => {
       };
 
       usersService.createMunicipalityUser.mockRejectedValue(
-        new Error('User with this email already exists'),
+        new ConflictException('User with this email already exists'),
       );
 
-      await expect(controller.createMunicipalityUser(dto)).rejects.toThrow(
-        'User with this email already exists',
+      await expect(controller.createMunicipalityUser(dto)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('deleteMunicipalityUserById', () => {
+    it('should delete a municipality user and return success', async () => {
+      usersService.deleteMunicipalityUserById.mockResolvedValue(undefined);
+
+      const result = await controller.deleteMunicipalityUserById('1');
+
+      expect(usersService.deleteMunicipalityUserById).toHaveBeenCalledWith('1');
+      expect(result).toEqual({ success: true, data: { id: '1' } });
+    });
+
+    it('should throw if UsersService.deleteMunicipalityUserById throws', async () => {
+      usersService.deleteMunicipalityUserById.mockRejectedValue(
+        new NotFoundException('Municipality user not found'),
       );
+
+      await expect(controller.deleteMunicipalityUserById('999')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateMunicipalityUserById', () => {
+    it('should update a municipality user and return success', async () => {
+      const dto: UpdateMunicipalityUserDto = {
+        email: 'updated@municipality.gov',
+        username: 'updated_user',
+      };
+
+      usersService.updateMunicipalityUserById.mockResolvedValue(undefined);
+
+      const result = await controller.updateMunicipalityUserById('1', dto);
+
+      expect(usersService.updateMunicipalityUserById).toHaveBeenCalledWith('1', dto);
+      expect(result).toEqual({ success: true, data: { id: '1' } });
+    });
+
+    it('should throw if UsersService.updateMunicipalityUserById throws NotFoundException', async () => {
+      const dto: UpdateMunicipalityUserDto = {
+        email: 'updated@municipality.gov',
+      };
+
+      usersService.updateMunicipalityUserById.mockRejectedValue(
+        new NotFoundException('Municipality user not found'),
+      );
+
+      await expect(controller.updateMunicipalityUserById('999', dto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw if UsersService.updateMunicipalityUserById throws ConflictException', async () => {
+      const dto: UpdateMunicipalityUserDto = {
+        email: 'duplicate@municipality.gov',
+      };
+
+      usersService.updateMunicipalityUserById.mockRejectedValue(
+        new ConflictException('Email already in use'),
+      );
+
+      await expect(controller.updateMunicipalityUserById('1', dto)).rejects.toThrow(ConflictException);
     });
   });
 });

--- a/apps/api/src/modules/users/users.service.spec.ts
+++ b/apps/api/src/modules/users/users.service.spec.ts
@@ -26,6 +26,8 @@ describe('UsersService', () => {
           provide: getRepositoryToken(User),
           useValue: {
             find: jest.fn(),
+            findOne: jest.fn(),
+            save: jest.fn(),
             manager: { transaction: mockTransaction },
           },
         },
@@ -61,6 +63,27 @@ describe('UsersService', () => {
         where: { role: { name: expect.anything() } }, // Not('user') è ignorato nel mock
       });
       expect(result).toEqual(mockUsers);
+    });
+  });
+
+  describe('findMunicipalityUserById', () => {
+    it('should return a municipality user by id', async () => {
+      const mockUser = { id: '1', email: 'admin@city.gov', role: { name: 'admin' } } as User;
+      userRepository.findOne.mockResolvedValue(mockUser);
+
+      const result = await service.findMunicipalityUserById('1');
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({
+        relations: ['role'],
+        where: { id: '1', role: { name: expect.anything() } },
+      });
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should throw NotFoundException if user is not found', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findMunicipalityUserById('999')).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -128,6 +151,133 @@ describe('UsersService', () => {
         firstName: dto.firstName,
         lastName: dto.lastName,
         role: { id: 'role-id', name: 'admin' },
+      });
+    });
+  });
+
+  describe('deleteMunicipalityUserById', () => {
+    it('should delete a municipality user and their account', async () => {
+      const mockUser = { id: '1', role: { name: 'admin' } } as User;
+      userRepository.findOne.mockResolvedValue(mockUser);
+
+      (userRepository.manager.transaction as jest.Mock).mockImplementation(async (fn) =>
+        fn({
+          getRepository: () => ({
+            delete: jest.fn().mockResolvedValue({ affected: 1 }),
+          }),
+        }),
+      );
+
+      await service.deleteMunicipalityUserById('1');
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({
+        relations: ['role'],
+        where: { id: '1', role: { name: expect.anything() } },
+      });
+    });
+
+    it('should throw NotFoundException if user is not found', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.deleteMunicipalityUserById('999')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateMunicipalityUserById', () => {
+    const updateDto = {
+      email: 'updated@example.com',
+      username: 'updateduser',
+      firstName: 'Updated',
+      lastName: 'User',
+    };
+
+    it('should update a municipality user successfully', async () => {
+      const mockUser = {
+        id: '1',
+        email: 'old@example.com',
+        username: 'olduser',
+        firstName: 'Old',
+        lastName: 'User',
+        roleId: 'role-id',
+      } as User;
+
+      userRepository.findOne
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(null);
+      userRepository.save.mockResolvedValue({ ...mockUser, ...updateDto });
+
+      await service.updateMunicipalityUserById('1', updateDto);
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { id: '1' } });
+      expect(userRepository.save).toHaveBeenCalledWith({
+        ...mockUser,
+        email: updateDto.email,
+        username: updateDto.username,
+        firstName: updateDto.firstName,
+        lastName: updateDto.lastName,
+      });
+    });
+
+    it('should throw NotFoundException if user is not found', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.updateMunicipalityUserById('999', updateDto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ConflictException if email is already in use', async () => {
+      const mockUser = { id: '1', email: 'old@example.com' } as User;
+      const existingUser = { id: '2', email: 'updated@example.com' } as User;
+
+      userRepository.findOne
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(existingUser);
+
+      await expect(service.updateMunicipalityUserById('1', { email: 'updated@example.com' })).rejects.toThrow(ConflictException);
+    });
+
+    it('should update user role if role is provided', async () => {
+      const mockUser = { id: '1', email: 'user@example.com', roleId: 'old-role-id' } as User;
+      const mockRole = { id: 'new-role-id', name: 'municipal_administrator' } as Role;
+
+      userRepository.findOne.mockResolvedValue(mockUser);
+      roleRepository.findOne.mockResolvedValue(mockRole);
+      userRepository.save.mockResolvedValue({ ...mockUser, roleId: mockRole.id });
+
+      await service.updateMunicipalityUserById('1', { role: 'municipal_administrator' });
+
+      expect(roleRepository.findOne).toHaveBeenCalledWith({ where: { name: 'municipal_administrator' } });
+      expect(userRepository.save).toHaveBeenCalledWith({
+        ...mockUser,
+        roleId: mockRole.id,
+      });
+    });
+
+    it('should throw NotFoundException if role is not found', async () => {
+      const mockUser = { id: '1', email: 'user@example.com' } as User;
+
+      userRepository.findOne.mockResolvedValue(mockUser);
+      roleRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.updateMunicipalityUserById('1', { role: 'invalid_role' })).rejects.toThrow(NotFoundException);
+    });
+
+    it('should update only provided fields (partial update)', async () => {
+      const mockUser = {
+        id: '1',
+        email: 'user@example.com',
+        username: 'username',
+        firstName: 'First',
+        lastName: 'Last',
+      } as User;
+
+      userRepository.findOne.mockResolvedValue(mockUser);
+      userRepository.save.mockResolvedValue({ ...mockUser, firstName: 'NewFirst' });
+
+      await service.updateMunicipalityUserById('1', { firstName: 'NewFirst' });
+
+      expect(userRepository.save).toHaveBeenCalledWith({
+        ...mockUser,
+        firstName: 'NewFirst',
       });
     });
   });


### PR DESCRIPTION
This pull request adds comprehensive unit tests for new and existing methods in both the `UsersController` and `UsersService` related to municipality user management. The tests now cover retrieving, updating, and deleting municipality users, including various success and error scenarios. This improves the reliability and maintainability of the user management features by ensuring edge cases and error handling are properly tested.

**Controller test enhancements (`users.controller.spec.ts`):**

- Added tests for getting a municipality user by ID, including handling not found errors.
- Added tests for deleting a municipality user by ID, including successful deletion and not found errors.
- Added tests for updating a municipality user by ID, covering successful updates, not found errors, email conflict errors, and partial updates.
- Improved error handling tests for user creation to expect `ConflictException` instead of a generic error.

**Service test enhancements (`users.service.spec.ts`):**

- Added tests for finding a municipality user by ID, including not found scenarios.
- Added tests for deleting a municipality user, including not found scenarios.
- Added extensive tests for updating a municipality user, including successful updates, not found errors, email conflict errors, role updates, role not found errors, and partial updates.
- Updated the user and role repository mocks to support the new test cases.