### PR TITLE
Allow PR Officer to Update Report State

### DIFF
--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -199,7 +199,7 @@ export class ReportsController {
    */
   @Patch(':id')
   @UseGuards(SessionGuard, RolesGuard)
-  @Roles('officier', 'user')
+  @Roles('pr_officer')
   async update(
     @Param('id') id: string,
     @Body() updateReportDto: UpdateReportDto,
@@ -217,7 +217,7 @@ export class ReportsController {
    */
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Roles('Officier')
+  @Roles('pr_officer')
   async remove(@Param('id') id: string) {
     await this.reportsService.remove(id);
   }


### PR DESCRIPTION
This PR updates the ReportsController to allow users with the pr_officer role to update the state of a report. The @Roles('pr_officer') decorator is now applied to the PATCH /reports/:id endpoint, enabling PR Officers to perform report updates.