### PR TITLE
merge dev to main (e2e UI tests updated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Build & Test
+name: CI - Build and Test
 
 on:
   push:
@@ -29,15 +29,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install
-      
+
       - name: Build packages (turbo)
         run: pnpm turbo run build
 
-      - name: Run tests (turbo)
-        run: pnpm turbo run test
-      
-      - name: Run e2e tests
-        run: pnpm turbo run test:e2e
+      - name: Run Unit Tests (Backend)
+        run: pnpm turbo run test --filter=api
+
+      - name: Run E2E tests (Backend)
+        run: pnpm turbo run test:e2e --filter=api

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,8 @@
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/apps/web/e2e/fixtures/auth-municipal-data.ts
+++ b/apps/web/e2e/fixtures/auth-municipal-data.ts
@@ -1,0 +1,140 @@
+export const createLoginResponse = (
+  roleName: 'admin' | 'user' | 'pr_officer' | 'tech_officer',
+) => {
+  const isMunicipal = roleName !== 'user';
+
+  const roleMap = {
+    admin: { id: 'role-admin', label: 'Admin' },
+    user: { id: 'role-user', label: 'User' },
+    pr_officer: { id: 'role-pr_officer', label: 'PR Officer' },
+    tech_officer: { id: 'role-tech_officer', label: 'Technical Officer' },
+  };
+
+  const roleInfo = roleMap[roleName] || roleMap['user'];
+
+  return {
+    status: 201,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      data: {
+        user: {
+          id: '123-uuid',
+          username: `test-${roleName}`,
+          email: `${roleName}@participium.com`,
+          firstName: 'Test',
+          lastName: 'User',
+          roleId: roleInfo.id,
+          role: {
+            id: roleInfo.id,
+            name: roleName,
+            label: roleInfo.label,
+            isMunicipal: isMunicipal,
+          },
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+        session: {
+          accessToken: 'fake-jwt-token-for-testing',
+        },
+      },
+    }),
+  };
+};
+
+export const createRegisterResponse = () => {
+  return createLoginResponse('user');
+};
+
+export const mockRoles = [
+  { id: 'role-admin', name: 'admin', label: 'Admin', isMunicipal: true },
+  {
+    id: 'role-pr_officer',
+    name: 'pr_officer',
+    label: 'PR Officer',
+    isMunicipal: true,
+  },
+  {
+    id: 'role-tech_officer',
+    name: 'tech_officer',
+    label: 'Technical Officer',
+    isMunicipal: true,
+  },
+  {
+    id: 'role-user',
+    name: 'user',
+    label: 'User',
+    isMunicipal: false,
+  },
+];
+
+export const mockOffices = [
+  {
+    id: 'maintenance',
+    name: 'maintenance',
+    label: 'Maintenance and Technical Services',
+  },
+  {
+    id: 'infrastructure',
+    name: 'infrastructure',
+    label: 'Infrastructure',
+  },
+  {
+    id: 'public_services',
+    name: 'public_services',
+    label: 'Local Public Services',
+  },
+  {
+    id: 'environment',
+    name: 'environment',
+    label: 'Environment Quality',
+  },
+  {
+    id: 'green_parks',
+    name: 'green_parks',
+    label: 'Green Areas and Parks',
+  },
+  {
+    id: 'civic_services',
+    name: 'civic_services',
+    label: 'Decentralization and Civic Services',
+  },
+];
+
+export const mockMunicipalityUsers = [
+  {
+    id: 'user-1',
+    username: 'tech_infrastructure_1',
+    email: 'tech.infra.1@participium.com',
+    firstName: 'Giovanni',
+    lastName: 'Bianchi',
+    role: mockRoles[2],
+    office: mockOffices[1],
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 'user-2',
+    username: 'pr_officer_1',
+    email: 'pr.officer.1@participium.com',
+    firstName: 'Laura',
+    lastName: 'Esposito',
+    role: mockRoles[1],
+    office: mockOffices[5],
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 'user-3',
+    username: 'tech_green_parks_1',
+    email: 'tech.parks.1@participium.com',
+    firstName: 'Anna',
+    lastName: 'Verdi',
+    role: mockRoles[2],
+    office: mockOffices[4],
+    createdAt: new Date().toISOString(),
+  },
+];
+
+export const createMutationResponse = (data: any) => ({
+  status: 201,
+  contentType: 'application/json',
+  body: JSON.stringify({ success: true, data }),
+});

--- a/apps/web/e2e/fixtures/report-data.ts
+++ b/apps/web/e2e/fixtures/report-data.ts
@@ -1,0 +1,117 @@
+import { mockOffices } from './auth-municipal-data.js';
+
+export const mockCategories = [
+  {
+    id: 'cat-roads',
+    name: 'Roads and Urban Furnishings',
+    office: mockOffices[0],
+  },
+  {
+    id: 'cat-lighting',
+    name: 'Public Lighting',
+    office: mockOffices[1],
+  },
+  {
+    id: 'cat-waste',
+    name: 'Waste',
+    office: mockOffices[3],
+  },
+  {
+    id: 'cat-barriers',
+    name: 'Architectural Barriers',
+    office: mockOffices[0],
+  },
+];
+
+export const mockEmptyReports = {
+  success: true,
+  data: [],
+};
+
+export const mockCreatedReportResponse = {
+  status: 201,
+  contentType: 'application/json',
+  body: JSON.stringify({
+    success: true,
+    data: {
+      id: 'new-report-123',
+      title: 'Deep pothole in the middle of the lane',
+      description:
+        'There is a very deep pothole in the center of the road. Dangerous for motorcycles.',
+      status: 'pending',
+      location: {
+        type: 'Point',
+        coordinates: [7.6784, 45.0621],
+      },
+      address: 'Corso Vittorio Emanuele II, 50, Torino',
+      images: ['pothole_1.jpg'],
+      categoryId: 'cat-roads',
+      category: mockCategories[0],
+      userId: '123-uuid',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  }),
+};
+
+export const mockExistingReports = {
+  success: true,
+  data: [
+    {
+      id: 'report-1',
+      title: 'Broken street lamp',
+      description:
+        'Street lamp totally burnt out, the sidewalk is pitch black.',
+      status: 'pending',
+      location: {
+        type: 'Point',
+        coordinates: [7.69, 45.0695],
+      },
+      address: 'Via Po, 18, Torino',
+      images: [],
+      categoryId: 'cat-lighting',
+      category: mockCategories[1],
+      userId: 'user-1',
+      createdAt: new Date(Date.now() - 86400000).toISOString(),
+      updatedAt: new Date(Date.now() - 86400000).toISOString(),
+    },
+    {
+      id: 'report-2',
+      title: 'Overflowing bins',
+      description: 'Trash is all over the floor, bins are full.',
+      status: 'in_progress',
+      location: {
+        type: 'Point',
+        coordinates: [7.683, 45.068],
+      },
+      address: 'Piazza San Carlo, Torino',
+      images: ['trash_full.jpg'],
+      categoryId: 'cat-waste',
+      category: mockCategories[2],
+      userId: 'user-2',
+      createdAt: new Date(Date.now() - 172800000).toISOString(),
+      updatedAt: new Date(Date.now() - 86400000).toISOString(),
+    },
+  ],
+};
+
+export function createMockReport(overrides: Partial<any> = {}) {
+  return {
+    id: `report-${Date.now()}`,
+    title: 'Test Report',
+    description: 'Test description',
+    status: 'pending',
+    location: {
+      type: 'Point',
+      coordinates: [7.6869, 45.0703],
+    },
+    address: 'Piazza Castello, Torino',
+    images: [],
+    categoryId: 'cat-roads',
+    category: mockCategories[0],
+    userId: '123-uuid',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}

--- a/apps/web/e2e/pages/AuthPage.ts
+++ b/apps/web/e2e/pages/AuthPage.ts
@@ -1,0 +1,50 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+export class AuthPage {
+  readonly page: Page;
+  readonly usernameInput: Locator;
+  readonly passwordInput: Locator;
+  readonly emailInput: Locator;
+  readonly firstNameInput: Locator;
+  readonly lastNameInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.usernameInput = page.locator('input[name="username"]');
+    this.passwordInput = page.locator('input[name="password"]');
+    this.emailInput = page.locator('input[name="email"]');
+    this.firstNameInput = page.locator('input[name="firstname"]');
+    this.lastNameInput = page.locator('input[name="lastname"]');
+    this.submitButton = page.locator('button[type="submit"]');
+  }
+
+  async gotoLogin() {
+    await this.page.goto('/auth/login');
+  }
+
+  async gotoRegister() {
+    await this.page.goto('/auth/register');
+  }
+
+  async login(username: string, pass: string) {
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(pass);
+    await this.submitButton.click();
+  }
+
+  async register(user: {
+    username: string;
+    email: string;
+    first: string;
+    last: string;
+    pass: string;
+  }) {
+    await this.usernameInput.fill(user.username);
+    await this.emailInput.fill(user.email);
+    await this.firstNameInput.fill(user.first);
+    await this.lastNameInput.fill(user.last);
+    await this.passwordInput.fill(user.pass);
+    await this.submitButton.click();
+  }
+}

--- a/apps/web/e2e/pages/UserPage.ts
+++ b/apps/web/e2e/pages/UserPage.ts
@@ -1,0 +1,104 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+export class MunicipalityUsersPage {
+  readonly page: Page;
+
+  readonly searchInput: Locator;
+  readonly roleFilterTrigger: Locator;
+  readonly officeFilterTrigger: Locator;
+  readonly clearFiltersButton: Locator;
+  readonly addUserButton: Locator;
+
+  readonly firstNameInput: Locator;
+  readonly lastNameInput: Locator;
+  readonly usernameInput: Locator;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+
+  readonly confirmDeleteButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.searchInput = page.getByPlaceholder('Search users...');
+    this.roleFilterTrigger = page
+      .getByRole('combobox')
+      .filter({ hasText: /role/i });
+    this.officeFilterTrigger = page
+      .getByRole('combobox')
+      .filter({ hasText: /office/i });
+    this.clearFiltersButton = page.getByRole('button', {
+      name: /Clear|Reset/i,
+    });
+    this.addUserButton = page.getByRole('button', { name: /Add User/i });
+
+    this.firstNameInput = page.locator('input[name="firstName"]');
+    this.lastNameInput = page.locator('input[name="lastName"]');
+    this.usernameInput = page.locator('input[name="username"]');
+    this.emailInput = page.locator('input[name="email"]');
+    this.passwordInput = page.locator('input[name="password"]');
+
+    this.submitButton = page.locator('button[type="submit"]');
+    this.confirmDeleteButton = page.getByRole('button', {
+      name: 'Delete User',
+    });
+  }
+
+  async goto() {
+    await this.page.goto('/app/municipality-users');
+  }
+
+  async search(query: string) {
+    await this.searchInput.fill(query);
+  }
+
+  async filterByRole(roleName: string) {
+    await this.roleFilterTrigger.click();
+    await this.page.getByRole('option', { name: roleName }).click();
+    await this.page.keyboard.press('Escape');
+  }
+
+  async openCreateDialog() {
+    await this.addUserButton.click();
+  }
+
+  async fillUserForm(user: any) {
+    await this.firstNameInput.fill(user.firstName);
+    await this.lastNameInput.fill(user.lastName);
+    await this.usernameInput.fill(user.username);
+    await this.emailInput.fill(user.email);
+
+    if (user.roleLabel) {
+      await this.page.locator('button:has-text("Select Role")').click();
+      await this.page.getByRole('option', { name: user.roleLabel }).click();
+    }
+
+    if (user.officeLabel) {
+      await this.page.locator('button:has-text("Select Office")').click();
+      await this.page.getByRole('option', { name: user.officeLabel }).click();
+    }
+
+    if (user.password) {
+      await this.passwordInput.fill(user.password);
+    }
+  }
+
+  async submit() {
+    await this.submitButton.click();
+  }
+
+  getRowByUsername(username: string) {
+    return this.page.locator('tr', { hasText: username });
+  }
+
+  async clickEdit(username: string) {
+    const row = this.getRowByUsername(username);
+    await row.locator('button:has(.lucide-pencil)').click();
+  }
+
+  async clickDelete(username: string) {
+    const row = this.getRowByUsername(username);
+    await row.locator('button:has(.lucide-trash-2)').click();
+  }
+}

--- a/apps/web/e2e/specs/auth.spec.ts
+++ b/apps/web/e2e/specs/auth.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { AuthPage } from '../pages/AuthPage.js';
+import {
+  createLoginResponse,
+  createRegisterResponse,
+} from '../fixtures/auth-municipal-data.js';
+
+test.describe('Auth Flow', () => {
+  let authPage: AuthPage;
+
+  test.beforeEach(async ({ page }) => {
+    authPage = new AuthPage(page);
+  });
+
+  test('Login Admin: redirect a Dashboard', async ({ page }) => {
+    await page.route('**/auth/login', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill(createLoginResponse('admin'));
+      } else {
+        await route.continue();
+      }
+    });
+
+    await authPage.gotoLogin();
+    await authPage.login('admin', 'passwordSegreta');
+
+    await expect(page.getByText('Login successful!')).toBeVisible();
+    await expect(page).toHaveURL(/\/app\/dashboard/);
+  });
+
+  test('Login Citizen: redirect a Report Map', async ({ page }) => {
+    await page.route('**/auth/login', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill(createLoginResponse('user'));
+      } else {
+        await route.continue();
+      }
+    });
+
+    await authPage.gotoLogin();
+    await authPage.login('mario_rossi', 'userPassword');
+
+    await expect(page).toHaveURL(/\/reports\/map/);
+  });
+
+  test('Login PR Officer: redirect a Dashboard', async ({ page }) => {
+    await page.route('**/auth/login', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill(createLoginResponse('pr_officer'));
+      } else {
+        await route.continue();
+      }
+    });
+
+    await authPage.gotoLogin();
+    await authPage.login('pr_officer_1', 'password');
+
+    await expect(page).toHaveURL(/\/app\/dashboard/);
+  });
+
+  test('Register as new citizen', async ({ page }) => {
+    await page.route('**/auth/register', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill(createRegisterResponse());
+      } else {
+        await route.continue();
+      }
+    });
+
+    await authPage.gotoRegister();
+    await authPage.register({
+      username: 'nuovo_cittadino',
+      email: 'new@citizen.com',
+      first: 'Mario',
+      last: 'Rossi',
+      pass: 'securePass123',
+    });
+
+    await expect(page.getByText('Registration successful!')).toBeVisible();
+    await expect(page).toHaveURL(/\/reports\/map/);
+  });
+
+  test('Manage Login: Invalid Credentials', async ({ page }) => {
+    await page.route('**/auth/login', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Invalid credentials' }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await authPage.gotoLogin();
+    await authPage.login('hacker', 'wrongPass');
+
+    await expect(page.getByText('Invalid credentials')).toBeVisible();
+    await expect(page).toHaveURL(/\/auth\/login/);
+  });
+});

--- a/apps/web/e2e/specs/municipality-users.spec.ts
+++ b/apps/web/e2e/specs/municipality-users.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from '@playwright/test';
+import { MunicipalityUsersPage } from '../pages/UserPage.js';
+import { AuthPage } from '../pages/AuthPage.js';
+import {
+  createLoginResponse,
+  createMutationResponse,
+  mockMunicipalityUsers,
+  mockOffices,
+  mockRoles,
+} from '../fixtures/auth-municipal-data.js';
+
+const successResponse = (data: any) => ({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify({ success: true, data }),
+});
+
+test.describe('Municipality Users Management (System Admin)', () => {
+  let usersPage: MunicipalityUsersPage;
+
+  test.beforeEach(async ({ page }) => {
+    usersPage = new MunicipalityUsersPage(page);
+    const authPage = new AuthPage(page);
+
+    await page.route('**/auth/login', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill(createLoginResponse('admin'));
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route('**/users/municipality', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: mockMunicipalityUsers }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.route('**/roles/', async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockRoles }),
+      }),
+    );
+
+    await page.route('**/offices', async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: mockOffices }),
+      }),
+    );
+
+    await authPage.gotoLogin();
+    await authPage.login('admin', 'admin');
+    await expect(page).toHaveURL(/\/app\/dashboard/);
+    await usersPage.goto();
+  });
+
+  test('Client-Side Filters: Search by name and filter by role', async ({
+    page,
+  }) => {
+    await expect(page.locator('tbody tr')).toHaveCount(3);
+
+    await usersPage.search('Giovanni');
+    await expect(page.locator('tbody tr')).toHaveCount(1);
+    await expect(
+      usersPage.getRowByUsername('tech_infrastructure_1'),
+    ).toBeVisible();
+
+    await usersPage.search('');
+    await expect(page.locator('tbody tr')).toHaveCount(3);
+
+    await usersPage.filterByRole('PR Officer');
+    await expect(page.locator('tbody tr')).toHaveCount(1);
+    await expect(
+      usersPage.getRowByUsername('tech_infrastructure_1'),
+    ).toBeHidden();
+  });
+
+  test('Create New Municipality User', async ({ page }) => {
+    const createPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes('/users/municipality') && req.method() === 'POST',
+    );
+
+    await page.route('**/users/municipality', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill(createMutationResponse({ id: 'new-user' }));
+      } else {
+        await route.fulfill(successResponse(mockMunicipalityUsers));
+      }
+    });
+
+    await usersPage.openCreateDialog();
+
+    await usersPage.fillUserForm({
+      firstName: 'Marco',
+      lastName: 'Rossi',
+      username: 'tech_maintenance_new',
+      email: 'tech.new@participium.com',
+      password: 'password123',
+      roleLabel: 'Tech Officer',
+      officeLabel: 'Maintenance and Technical Services',
+    });
+
+    await usersPage.submit();
+
+    const request = await createPromise;
+    const postData = request.postDataJSON();
+
+    expect(postData).toMatchObject({
+      username: 'tech_maintenance_new',
+      email: 'tech.new@participium.com',
+      roleId: 'role-tech_officer',
+      officeId: 'maintenance',
+    });
+
+    await expect(
+      page.getByText('Municipality user created successfully'),
+    ).toBeVisible();
+  });
+
+  test('Update existing municipality user', async ({ page }) => {
+    const userToEdit = mockMunicipalityUsers[0]!;
+
+    const updatePromise = page.waitForRequest(
+      (req) =>
+        req.url().includes(`/users/municipality/user/${userToEdit.id}`) &&
+        req.method() === 'POST',
+    );
+
+    await page.route(
+      `**/users/municipality/user/${userToEdit.id}`,
+      async (route) => {
+        if (route.request().method() === 'POST') {
+          await route.fulfill(createMutationResponse({ id: userToEdit.id }));
+        }
+      },
+    );
+
+    await usersPage.clickEdit(userToEdit.username);
+    await expect(usersPage.usernameInput).toHaveValue(userToEdit.username);
+
+    await usersPage.firstNameInput.fill('Mario Updated');
+    await usersPage.lastNameInput.fill('Rossi Updated');
+    await usersPage.usernameInput.fill('mario.rossi.updated');
+    await usersPage.emailInput.fill('mario@updated.com');
+
+    await usersPage.submit();
+
+    const request = await updatePromise;
+    const postData = request.postDataJSON();
+
+    expect(postData).toMatchObject({
+      firstName: 'Mario Updated',
+      lastName: 'Rossi Updated',
+      username: 'mario.rossi.updated',
+      email: 'mario@updated.com',
+    });
+
+    await expect(page.getByText('User updated successfully')).toBeVisible();
+  });
+
+  test('Delete existing municipality user', async ({ page }) => {
+    const userToDelete = mockMunicipalityUsers[1]!;
+
+    const deletePromise = page.waitForRequest(
+      (req) =>
+        req.url().includes(`/users/municipality/user/${userToDelete.id}`) &&
+        req.method() === 'DELETE',
+    );
+
+    await page.route(
+      `**/users/municipality/user/${userToDelete.id}`,
+      async (route) => {
+        if (route.request().method() === 'DELETE') {
+          await route.fulfill(createMutationResponse({ id: userToDelete.id }));
+        }
+      },
+    );
+
+    await usersPage.clickDelete(userToDelete.username);
+    await usersPage.confirmDeleteButton.click();
+
+    await deletePromise;
+    await expect(
+      page.getByText(`User "${userToDelete.username}" deleted successfully`),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,9 @@
     "dev": "vite --clearScreen false",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\"",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "-": "^0.0.1",
@@ -48,6 +50,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@repo/api": "workspace:*",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+  ],
+
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.2)(react@18.3.1)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.57.0
       '@repo/api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -2405,6 +2408,14 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@playwright/test@1.57.0:
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.57.0
+    dev: true
 
   /@radix-ui/number@1.1.1:
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -6267,6 +6278,14 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -8649,6 +8668,22 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
+    dev: true
+
+  /playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /pluralize@8.0.0:


### PR DESCRIPTION
This pull request introduces Playwright-based end-to-end (E2E) testing to the `apps/web` project, including configuration, test fixtures, page objects, and initial test suites for authentication and municipality user management. It also updates CI workflows to support these tests and improves dependency management. The most important changes are grouped below:

**End-to-End Testing Infrastructure**

* Added Playwright configuration file (`playwright.config.ts`) to enable E2E testing across multiple browsers and devices, with CI support and HTML reporting.
* Created test fixtures (`auth-municipal-data.ts`, `report-data.ts`) and page object models (`AuthPage.ts`, `UserPage.ts`) to support robust and maintainable E2E tests.
* Implemented E2E test suites for authentication flows and municipality user management, covering login, registration, user CRUD, and filtering scenarios. [

**Project Configuration and Dependency Management**

* Added Playwright as a dev dependency and defined new scripts (`test:e2e`, `test:e2e:ui`) in `package.json` for running E2E tests.
* Updated `.gitignore` to exclude Playwright-related files and directories, ensuring test artifacts are not committed.

**Continuous Integration (CI) Workflow Improvements**

* Updated the CI workflow (`ci.yml`) to cache `pnpm` dependencies and to run backend unit and E2E tests with improved clarity in step naming.