### PR TITLE
fix(issue): fixed suspended issue and updated documentation

### DIFF
--- a/apps/api/src/common/entities/report.entity.ts
+++ b/apps/api/src/common/entities/report.entity.ts
@@ -17,6 +17,7 @@ export enum ReportStatus {
   RESOLVED = 'resolved',
   REJECTED = 'rejected',
   ASSIGNED = 'assigned',
+  SUSPENDED = 'suspended',
 }
 
 @Entity('report')

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -241,8 +241,10 @@ export class ReportsService {
         'assignedExternalMaintainer',
       );
 
-    // For public users, only show reports that are not rejected
-    query.andWhere(`report.status != 'rejected'`);
+    // For public users, only show reports that are assigned, in_progress, suspended, or resolved
+    query.andWhere(
+      `report.status IN ('assigned', 'in_progress', 'suspended', 'resolved')`,
+    );
 
     if (filters?.status) {
       query.andWhere('report.status = :status', { status: filters.status });
@@ -550,9 +552,10 @@ export class ReportsService {
     const allowedTransitions: Record<ReportStatus, string[]> = {
       pending: [],
       assigned: ['in_progress'],
-      in_progress: ['resolved'],
+      in_progress: ['resolved', 'suspended'],
       resolved: [],
       rejected: [],
+      suspended: ['in_progress'],
     };
 
     const allowedNextStatuses = allowedTransitions[report.status];

--- a/apps/api/test/jest-int.json
+++ b/apps/api/test/jest-int.json
@@ -11,7 +11,7 @@
   "forceExit": true,
   "detectOpenHandles": true,
   "moduleNameMapper": {
-    "^@entities$": "<rootDir>/src/common/entities/index.ts",
-    "^@entities/(.*)$": "<rootDir>/src/common/entities/$1"
+    "^@entities$": "<rootDir>/../src/common/entities/index.ts",
+    "^@entities/(.*)$": "<rootDir>/../src/common/entities/$1"
   }
 }

--- a/apps/web/src/components/external/view-report-form.tsx
+++ b/apps/web/src/components/external/view-report-form.tsx
@@ -53,7 +53,9 @@ export function ViewAssignedExternalReport({
       case 'assigned':
         return ['assigned', 'in_progress'];
       case 'in_progress':
-        return ['in_progress', 'resolved'];
+        return ['in_progress', 'resolved', 'suspended'];
+      case 'suspended':
+        return ['suspended', 'in_progress'];
       case 'resolved':
         return ['resolved'];
       default:

--- a/apps/web/src/components/reports-map/map.utils.ts
+++ b/apps/web/src/components/reports-map/map.utils.ts
@@ -45,6 +45,12 @@ export const STATUS_COLORS = {
     class: 'cluster-assigned',
     badgeClass: 'bg-purple-500/15 text-purple-700 border-purple-200',
   },
+  ['suspended']: {
+    hex: '#6b7280',
+    label: 'Suspended',
+    class: 'cluster-suspended',
+    badgeClass: 'bg-gray-500/15 text-gray-700 border-gray-200',
+  },
 };
 
 export const DEFAULT_COLOR = {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -37,6 +37,12 @@ export const getStatusConfig = (status: ReportStatus) => {
         color:
           'bg-red-500/15 text-purple-700 hover:bg-purple-500/25 border-purple-200',
       };
+    case 'suspended':
+      return {
+        label: 'Suspended',
+        color:
+          'bg-gray-500/15 text-gray-700 hover:bg-gray-500/25 border-gray-200',
+      };
     default:
       return { label: status, color: 'bg-gray-100 text-gray-700' };
   }

--- a/apps/web/src/types/entities.ts
+++ b/apps/web/src/types/entities.ts
@@ -57,7 +57,8 @@ export type ReportStatus =
   | 'in_progress'
   | 'resolved'
   | 'rejected'
-  | 'assigned';
+  | 'assigned'
+  | 'suspended';
 
 export type Report = {
   id: string;

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -533,7 +533,7 @@ Files: `src/api/client.ts` and `src/api/endpoints/`
 | id                           | string   | Primary key                     | No       | varchar                                                                                                    |
 | title                        | string   | Report title                    | Yes      | varchar, optional                                                                                          |
 | description                  | string   | Report description              | Yes      | text type, optional                                                                                        |
-| status                       | enum     | Report status                   | No       | Values: pending, in_progress, resolved, rejected, assigned. Default: pending. Visibility rules apply.      |
+| status                       | enum     | Report status                   | No       | Values: pending, in_progress, resolved, rejected, assigned, suspended. Default: pending. Visibility rules apply.      |
 | location                     | Point    | Geographic coordinates          | No       | PostGIS geometry(Point, 4326). Must be within municipal boundaries.                                        |
 | address                      | string   | Physical address                | Yes      | varchar, optional                                                                                          |
 | images                       | string[] | Array of image paths/URLs       | No       | varchar array                                                                                              |
@@ -935,6 +935,28 @@ To run the seed manually:
 cd apps/api
 pnpm run seed:participium
 ```
+
+#### Test User Credentials
+
+After seeding the database, you can use the following credentials for testing purposes:
+
+**Default Password for All Users**: `password`
+
+| Role                    | Username                                   | Name                     | Email                                        | Office                                  |
+| ----------------------- | ------------------------------------------ | ------------------------ | -------------------------------------------- | --------------------------------------- |
+| **System Admin**        | `system_admin`                             | System Admin             | admin@participium.com                        | Organization Office                     |
+| **PR Officers**         | `pr_officer_1` to `pr_officer_4`           | PR Officer 1, 2, 3, 4    | pr.officer.1@participium.com (etc.)          | Organization Office                     |
+| **Tech Officers**       | `tech_maintenance_1`, `tech_maintenance_2` | Random (Faker-generated) | tech_maintenance_1@participium.com (etc.)    | Maintenance and Technical Services      |
+|                         | `tech_infrastructure_1`, etc.              | Random (Faker-generated) | tech_infrastructure_1@participium.com (etc.) | Infrastructure                          |
+|                         | `tech_public_services_1`, etc.             | Random (Faker-generated) | tech_public_services_1@participium.com       | Local Public Services                   |
+|                         | `tech_environment_1`, etc.                 | Random (Faker-generated) | tech_environment_1@participium.com           | Environment Quality                     |
+|                         | `tech_green_parks_1`, etc.                 | Random (Faker-generated) | tech_green_parks_1@participium.com           | Green Areas and Parks                   |
+|                         | `tech_civic_services_1`, etc.              | Random (Faker-generated) | tech_civic_services_1@participium.com        | Decentralization and Civic Services     |
+| **External Maintainer** | `external_company_1_1`, etc.               | Random (Faker-generated) | external_company_1_1@participium.com         | External Company 1, 2, or 3             |
+| **Citizens**            | `mario_rossi`                              | Mario Rossi              | mario.rossi@gmail.com                        | -                                       |
+|                         | `luigi_verdi`                              | Luigi Verdi              | luigi.verdi@gmail.com                        | -                                       |
+
+**Note**: Each office has 2 tech officers (`_1` and `_2`), and each external company has 2 maintainers. Tech officer and external maintainer names are randomly generated using Faker library at seed time.
 
 #### Individual applications
 


### PR DESCRIPTION
added suspended status to report and to the general flow:
- pr officers can go from "in_progress" to "suspended" and back (this is the only transition available
- citizen and guests can see suspended reports on the map

also added table to documentation with various test accounts